### PR TITLE
typo starklark -> starlark appears in VSCode Marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
         "name": "Peter Hagen"
     },
     "license": "MIT",
-    "homepage": "https://github.com/phgn0/vscode-starklark",
+    "homepage": "https://github.com/phgn0/vscode-starlark",
     "repository": {
         "type": "git",
-        "url": "https://github.com/phgn0/vscode-starklark"
+        "url": "https://github.com/phgn0/vscode-starlark"
     },
     "bugs": {
-        "url": "https://github.com/phgn0/vscode-starklark/issues"
+        "url": "https://github.com/phgn0/vscode-starlark/issues"
     },
     "qna": "https://stackoverflow.com/questions/tagged/visual-studio-code+python",
     "icon": "icon.png",


### PR DESCRIPTION
The typo appears in VSCode marketplace making this repo impossible to find.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
